### PR TITLE
Fix playground

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -95,8 +95,6 @@ const policies: Policy[] = [
 const bunjil: Bunjil = new Bunjil({
     // Server config
     server: {
-        hostname: `localhost`,
-        protocol: `http`,
         port: 3000,
         tracing: true,
         cacheControl: true,
@@ -125,7 +123,7 @@ await bunjil.start();
 
 ## Running the tests
 
-Use `yarn tests` or `npm run tests`.
+Use `yarn test` or `npm run test`.
 
 Tests are written with `ava`, and we would strongly like tests with any new functionality.
 

--- a/src/bunjil.ts
+++ b/src/bunjil.ts
@@ -67,8 +67,6 @@ class Bunjil {
     public koa: Koa;
     private router: KoaRouter;
     public serverConfig: {
-        protocol: string;
-        hostname: string;
         port?: number;
         tracing: boolean;
         cacheControl: boolean;
@@ -142,8 +140,6 @@ class Bunjil {
         // Setup the serverConfig
         this.serverConfig = {
             ...options.server,
-            protocol: options.server.protocol,
-            hostname: options.server.hostname,
             tracing:
                 typeof options.server.tracing === "boolean"
                     ? options.server.tracing
@@ -389,9 +385,7 @@ class Bunjil {
         if (this.playgroundOptions.enabled) {
             const playgroundOptions: playgroundOptions = {
                 ...this.playgroundOptions,
-                endpoint: `${this.serverConfig.protocol}://${
-                    this.serverConfig.hostname
-                }:${this.serverConfig.port}${this.endpoints.graphQL}`,
+                endpoint: this.endpoints.graphQL,
             };
             this.router.get(
                 this.endpoints.playground,
@@ -420,11 +414,9 @@ class Bunjil {
 
         this.logger.debug("Starting Koa");
         // Start Koa
-        this.koa.listen(this.serverConfig.port, this.serverConfig.hostname);
+        this.koa.listen(this.serverConfig.port);
         this.logger.debug(
-            `Bunjil running at ${this.serverConfig.protocol}://${
-                this.serverConfig.hostname
-            }:${this.serverConfig.port}`,
+            `Bunjil running at port ${this.serverConfig.port}`,
         );
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,8 +33,6 @@ type BunjilOptions = {
 
     // Koa
     server: {
-        protocol: string;
-        hostname: string;
         port?: number;
         tracing?: boolean | undefined;
 

--- a/tests/integration/authorization.spec.ts
+++ b/tests/integration/authorization.spec.ts
@@ -169,8 +169,6 @@ test("Can authenticate, and run authorized query", async t => {
 
     const bunjil: Bunjil = new Bunjil({
         server: {
-            hostname: `localhost`,
-            protocol: `http`,
             tracing: false,
             cacheControl: false,
         },
@@ -458,8 +456,6 @@ test("Restrict access to a type based on userId", async t => {
 
     const bunjil: Bunjil = new Bunjil({
         server: {
-            hostname: `localhost`,
-            protocol: `http`,
             tracing: false,
             cacheControl: false,
         },

--- a/tests/integration/cacheControl.spec.ts
+++ b/tests/integration/cacheControl.spec.ts
@@ -66,8 +66,6 @@ test("Can cache top level queries", async t => {
 
     const bunjil: Bunjil = new Bunjil({
         server: {
-            hostname: `localhost`,
-            protocol: `http`,
             tracing: false,
             cacheControl: true,
         },
@@ -181,8 +179,6 @@ test("Can cache individual fields", async t => {
 
     const bunjil: Bunjil = new Bunjil({
         server: {
-            hostname: `localhost`,
-            protocol: `http`,
             tracing: false,
             cacheControl: true,
         },

--- a/tests/integration/schemaMerging.spec.ts
+++ b/tests/integration/schemaMerging.spec.ts
@@ -62,8 +62,6 @@ test("Can merge schemas, and mask a type", async t => {
 
     const bunjil: Bunjil = new Bunjil({
         server: {
-            hostname: `localhost`,
-            protocol: `http`,
             tracing: false,
             cacheControl: false,
         },

--- a/tests/integration/simpleServer.spec.ts
+++ b/tests/integration/simpleServer.spec.ts
@@ -64,8 +64,6 @@ test("Can create server with a simple schema, and respond to query", async t => 
 
     const bunjil: Bunjil = new Bunjil({
         server: {
-            hostname: `localhost`,
-            protocol: `http`,
             tracing: false,
             cacheControl: false,
         },
@@ -171,8 +169,6 @@ test("Performance of simple query with policy", async t => {
 
     const bunjil: Bunjil = new Bunjil({
         server: {
-            hostname: `localhost`,
-            protocol: `http`,
             tracing: false,
             cacheControl: false,
         },


### PR DESCRIPTION
This PR gets rid of hostname as 

1) `hostname` should not be required by playground, because it is served always from the same server the proxy is being saved so using just `endpoint` option to koa playground middleare is enough
2) the only place `protocol` was used was exactly in the playground. So, not required anymore
2) `hostname` causes issies while listening using `http`. For some reason node tries to replace the name passed as argument by the resolved ip. Setting `0.0.0.0` is not possible because it is treated as a hostname thus causing the need for CORS in case you access via `localhost` or any other name for example.

I find the best option is to get rid of anything related to `hostname`.